### PR TITLE
カレンダーの作成PR

### DIFF
--- a/ruby/calendar.rb
+++ b/ruby/calendar.rb
@@ -1,52 +1,29 @@
 # frozen_string_literal: true
 
 require 'optparse'
+require 'date'
 
 opt = OptionParser.new
 
 option_params = {}
-opt.on('-m') { |v| v }
+opt.on('-m VAL') { |v| v }
 opt.parse!(ARGV, into: option_params)
 
-# 月毎の日数
-@number_of_days_in_month = {
-  january: 1..31,
-  february: 1..28,
-  march: 1..31,
-  april: 1..30,
-  may: 1..31,
-  june: 1..30,
-  july: 1..31,
-  august: 1..31,
-  september: 1..30,
-  october: 1..31,
-  november: 1..30,
-  december: 1..31
-}
-
-# 表示用の曜日
-@display_weeks = %w[月 火 水 木 金 土 日]
-
-@current_year = Time.now.year
-@select_month = Time.now.month
+this_year = Date.today.year
+select_month = option_params[:m] || Date.today.mon.to_s
 
 # 表示する月の最初の曜日を取得する
-def first_month_wday
+def first_month_wday(year, month)
   day_weeks = %w[日 月 火 水 木 金 土]
-  day_weeks[Time.new(@current_year, @select_month, 1).strftime('%w').to_i]
+  day_weeks[Date.new(year, month).strftime('%w').to_i]
 end
 
 # 日にちの成形
-def display_days
-  month_english_name = Time.new(@current_year, @select_month).strftime('%B').downcase
-
-  # うるう年の判定
-  @number_of_days_in_month[:february] = 1..29 if Time.new(@current_year, 12, 31).yday == 366
-
-  days = @number_of_days_in_month[month_english_name.to_sym].to_a.map do |day|
+def display_days(year, month)
+  days = (1..Date.new(year, month, -1).day).to_a.map do |day|
     day.to_s.rjust(2)
   end
-  @display_weeks.index(first_month_wday).times { days.unshift '  ' }
+  %w[月 火 水 木 金 土 日].index(first_month_wday(year, month)).times { days.unshift '  ' }
   days
 end
 
@@ -60,21 +37,16 @@ def display_calendar(days)
 end
 
 # ターミナルへの表示
-def display_terminal(display_days)
-  puts "#{@select_month}月 #{@current_year}年".center(21)
-  puts @display_weeks.join(' ').rjust(14)
-  puts display_calendar(display_days).join(' ')
+def display_terminal(year, month)
+  days = display_days(year, month)
+  puts "#{month}月 #{year}年".center(21)
+  puts %w[月 火 水 木 金 土 日].join(' ').rjust(14)
+  puts display_calendar(days).join(' ')
 end
 
-# option_params[:m]の値がfalseの場合、当月を表示する(-m入力がない)
-if !option_params[:m]
-  # 当月のカレンダーを表示
-  display_terminal(display_days)
-elsif Range.new(1, 12).to_a.find { |i| i == ARGV[0].to_i }
-  # コマンドで指定されたカレンダーを表示
-  @select_month = ARGV[0].to_s.rjust(2).gsub(/ /, '0').to_i
-  display_terminal(display_days)
-else
-  # 不正な値を入力するとエラーを表示する
-  raise "#{ARGV[0]} is neither a month number (1..12) nor a name"
+# オプション入力が不正な値の場合、エラーを表示
+raise "#{select_month} is neither a month number (1..12) nor a name" unless Range.new('1', '12').to_a.find do |i|
+  i == select_month
 end
+
+display_terminal(this_year, select_month.to_i)

--- a/ruby/calendar.rb
+++ b/ruby/calendar.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+opt = OptionParser.new
+
+option_params = {}
+opt.on('-m') { |v| v }
+opt.parse!(ARGV, into: option_params)
+
+# 月毎の日数
+@number_of_days_in_month = {
+  january: 1..31,
+  february: 1..28,
+  march: 1..31,
+  april: 1..30,
+  may: 1..31,
+  june: 1..30,
+  july: 1..31,
+  august: 1..31,
+  september: 1..30,
+  october: 1..31,
+  november: 1..30,
+  december: 1..31
+}
+
+# 表示用の曜日
+@display_weeks = %w[月 火 水 木 金 土 日]
+
+@current_year = Time.now.year
+@select_month = Time.now.month
+
+# 表示する月の最初の曜日を取得する
+def first_month_wday
+  day_weeks = %w[日 月 火 水 木 金 土]
+  day_weeks[Time.new(@current_year, @select_month, 1).strftime('%w').to_i]
+end
+
+# 日にちの成形
+def display_days
+  month_english_name = Time.new(@current_year, @select_month).strftime('%B').downcase
+
+  # うるう年の判定
+  @number_of_days_in_month[:february] = 1..29 if Time.new(@current_year, 12, 31).yday == 366
+
+  days = @number_of_days_in_month[month_english_name.to_sym].to_a.map do |day|
+    day.to_s.rjust(2)
+  end
+  @display_weeks.index(first_month_wday).times { days.unshift '  ' }
+  days
+end
+
+# 日にちをカレンダー表示へ成形
+def display_calendar(days)
+  days.map.with_index do |day, i|
+    day.concat("\n") if ((i + 1) % 7).zero?
+  end
+  days.push("\n")
+  days.unshift('')
+end
+
+# ターミナルへの表示
+def display_terminal(display_days)
+  puts "#{@select_month}月 #{@current_year}年".center(21)
+  puts @display_weeks.join(' ').rjust(14)
+  puts display_calendar(display_days).join(' ')
+end
+
+# option_params[:m]の値がfalseの場合、当月を表示する(-m入力がない)
+if !option_params[:m]
+  # 当月のカレンダーを表示
+  display_terminal(display_days)
+elsif Range.new(1, 12).to_a.find { |i| i == ARGV[0].to_i }
+  # コマンドで指定されたカレンダーを表示
+  @select_month = ARGV[0].to_s.rjust(2).gsub(/ /, '0').to_i
+  display_terminal(display_days)
+else
+  # 不正な値を入力するとエラーを表示する
+  raise "#{ARGV[0]} is neither a month number (1..12) nor a name"
+end

--- a/ruby/calendar.rb
+++ b/ruby/calendar.rb
@@ -9,8 +9,8 @@ option_params = {}
 opt.on('-m VAL') { |v| v }
 opt.parse!(ARGV, into: option_params)
 
-this_year = Date.today.year
-select_month = option_params[:m] || Date.today.mon.to_s
+today = Date.today
+select_month = option_params[:m] || today.mon.to_s
 
 # 表示する月の最初の曜日を取得する
 def first_month_wday(year, month)
@@ -49,4 +49,4 @@ raise "#{select_month} is neither a month number (1..12) nor a name" unless Rang
   i == select_month
 end
 
-display_terminal(this_year, select_month.to_i)
+display_terminal(today.year, select_month.to_i)


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/08_ruby/002_%E3%82%AB%E3%83%AC%E3%83%B3%E3%83%80%E3%83%BC%E3%82%92%E4%BD%9C%E3%82%8B.md

## やったこと

* カレンダーの作成


## 動作確認方法

* `ruby calendar.rb` 単体で今年の今月のカレンダーが表示されます
* `-m 1..12` のオプションを付けると、指定した月の今年のカレンダーを表示できます
* オプションの数値が未入力または不正な値だとエラーが出ます

## その他

* 下記はrubocopを通した結果と、オプション無し & オプション付きで1月、2月、3月を出力した結果のSSになります
![calendar実行結果](https://github.com/K-Akira928/hc_practice/assets/134822923/55a69dcc-b92b-47df-9b9e-d2ec086519d2)
