### PR TITLE
Suica版自動販売機問題作成PR

### DIFF
--- a/ruby/vending_machine/Rakefile
+++ b/ruby/vending_machine/Rakefile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.pattern = 'test/**/*_test.rb'
+end
+
+task default: :test

--- a/ruby/vending_machine/lib/advance_vending_machine.rb
+++ b/ruby/vending_machine/lib/advance_vending_machine.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative 'vending_machine'
+
+# 機能を増やした自販機クラスです
+class AdvanceVendingMachine < VendingMachine
+  # 新たに2種類のジュースインスタンスでジュースを管理できるようにする
+  def initialize(juice, second_juice, third_juice)
+    super(juice)
+    # ジュースのリストに追加した2種類の情報を追加
+    @juice_list.store(second_juice.juice_name, { price: second_juice.juice_price, stock: second_juice.juice_stock })
+    @juice_list.store(third_juice.juice_name, { price: third_juice.juice_price, stock: third_juice.juice_stock })
+  end
+
+  # Suicaの残高と現在の在庫で購入可能なジュースのリストを返す
+  def juice_buy_possible_list(suica)
+    buy_possible_list = @juice_list.map do |keys, _value|
+      keys if suica.deposit >= @juice_list[keys][:price] && @juice_list[keys][:stock].positive?
+    end
+    buy_possible_list.compact
+  end
+
+  # ジュースのストック(在庫)を増やす
+  def juice_stock_add(juice_name, num)
+    @juice_list[juice_name][:stock] += num
+  end
+end

--- a/ruby/vending_machine/lib/advance_vending_machine.rb
+++ b/ruby/vending_machine/lib/advance_vending_machine.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'vending_machine'
+require_relative '../lib/vending_machine'
 
 # 機能を増やした自販機クラスです
 class AdvanceVendingMachine < VendingMachine
@@ -8,20 +8,31 @@ class AdvanceVendingMachine < VendingMachine
   def initialize(juice, second_juice, third_juice)
     super(juice)
     # ジュースのリストに追加した2種類の情報を追加
-    @juice_list.store(second_juice.juice_name, { price: second_juice.juice_price, stock: second_juice.juice_stock })
-    @juice_list.store(third_juice.juice_name, { price: third_juice.juice_price, stock: third_juice.juice_stock })
+    second_juices = []
+    third_juices = []
+    5.times { second_juices.push Juice.new(second_juice[0], second_juice[1]) }
+    5.times { third_juices.push Juice.new(third_juice[0], third_juice[1]) }
+    @juice_list.store(second_juice[0], second_juices)
+    @juice_list.store(third_juice[0], third_juices)
+
+    # ジュースの設計図を保管
+    @juice_info_list = [juice, second_juice, third_juice]
   end
 
   # Suicaの残高と現在の在庫で購入可能なジュースのリストを返す
   def juice_buy_possible_list(suica)
-    buy_possible_list = @juice_list.map do |keys, _value|
-      keys if suica.deposit >= @juice_list[keys][:price] && @juice_list[keys][:stock].positive?
+    buy_possible_list = @juice_list.map do |key, _value|
+      key if @juice_list[key].size.positive? && suica.deposit >= @juice_list[key].first.juice_price
     end
     buy_possible_list.compact
   end
 
   # ジュースのストック(在庫)を増やす
   def juice_stock_add(juice_name, num)
-    @juice_list[juice_name][:stock] += num
+    index = @juice_info_list.map.with_index do |juice, i|
+      i if juice_name == juice[0]
+    end
+    index = index.compact[0]
+    num.times { @juice_list[juice_name].push Juice.new(@juice_info_list[index][0], @juice_info_list[index][1]) }
   end
 end

--- a/ruby/vending_machine/lib/juice.rb
+++ b/ruby/vending_machine/lib/juice.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# ジュースを作成するためのクラスです
+class Juice
+  attr_reader :juice_name, :juice_price, :juice_stock
+
+  # ジュースは名前、値段、在庫の情報を持つ(デフォルトではペプシ、150円、5個の在庫)
+  def initialize(juice_name = 'ペプシ', price = 150, stock = 5)
+    @juice_name = juice_name
+    @juice_price = price
+    @juice_stock = stock
+  end
+end

--- a/ruby/vending_machine/lib/juice.rb
+++ b/ruby/vending_machine/lib/juice.rb
@@ -2,12 +2,11 @@
 
 # ジュースを作成するためのクラスです
 class Juice
-  attr_reader :juice_name, :juice_price, :juice_stock
+  attr_reader :juice_name, :juice_price
 
-  # ジュースは名前、値段、在庫の情報を持つ(デフォルトではペプシ、150円、5個の在庫)
-  def initialize(juice_name = 'ペプシ', price = 150, stock = 5)
+  # ジュースは名前、値段、の情報を持つ
+  def initialize(juice_name, price)
     @juice_name = juice_name
     @juice_price = price
-    @juice_stock = stock
   end
 end

--- a/ruby/vending_machine/lib/suica.rb
+++ b/ruby/vending_machine/lib/suica.rb
@@ -18,6 +18,9 @@ class Suica
 
   # Suicaの残高を減らす
   def deposit_sub(price)
+    # Suicaの残高を超えて減算しようとするとエラー
+    raise '残高が足りません' if @deposit < price
+
     @deposit -= price
   end
 end

--- a/ruby/vending_machine/lib/suica.rb
+++ b/ruby/vending_machine/lib/suica.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Suicaクラスです
+class Suica
+  attr_reader :deposit
+
+  # デフォルトで500円チャージ
+  def initialize
+    @deposit = 500
+  end
+
+  # Suicaに任意の額をチャージ(100円未満ではエラー)
+  def deposit_charge(amount)
+    raise 'チャージ額は100円以上で入力してください' if amount < 100
+
+    @deposit += amount
+  end
+
+  # Suicaの残高を減らす
+  def deposit_sub(price)
+    @deposit -= price
+  end
+end

--- a/ruby/vending_machine/lib/vending_machine.rb
+++ b/ruby/vending_machine/lib/vending_machine.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# 自動販売機クラス
+class VendingMachine
+  attr_reader :sales_amount
+
+  # ジュースインスタンスを渡して自動販売機を作成します
+  def initialize(juice)
+    # ジュースのリストをハッシュで作成
+    @juice_list = {}
+    @juice_list.store(juice.juice_name, { price: juice.juice_price, stock: juice.juice_stock })
+
+    # 自動販売機の売上金額
+    @sales_amount = 0
+  end
+
+  # ジュースの購入処理
+  def juice_buy(suica, juice_name)
+    raise 'チャージ額またはジュースの在庫がありません' unless juice_buy?(suica, juice_name)
+
+    # 自販機内のジュースの在庫を減らし、ジュースの値段分Suicaから引く、ジュースの値段分自販機の売上金額に追加
+    @juice_list[juice_name][:stock] -= 1
+    # suica.deposit_juice_price_sub(@juice_list[juice_name][:price])
+    @sales_amount += @juice_list[juice_name][:price]
+    suica.deposit_sub(@juice_list[juice_name][:price])
+  end
+
+  # ジュースのストックを確認
+  def juice_stock(juice_name)
+    @juice_list[juice_name][:stock]
+  end
+
+  # Suicaの残高とジュースのストックで購入可能か判定
+  def juice_buy?(suica, juice_name)
+    juice_stock(juice_name).positive? && suica.deposit >= @juice_list[juice_name][:price]
+  end
+end

--- a/ruby/vending_machine/lib/vending_machine.rb
+++ b/ruby/vending_machine/lib/vending_machine.rb
@@ -4,12 +4,12 @@
 class VendingMachine
   attr_reader :sales_amount
 
-  # ジュースインスタンスを渡して自動販売機を作成します
-  def initialize(juice)
+  # ジュースの情報を渡してインスタンスを生成する(デフォルトではペプシ、150円)
+  def initialize(juice = ['ペプシ', 150])
     # ジュースのリストをハッシュで作成
-    @juice_list = {}
-    @juice_list.store(juice.juice_name, { price: juice.juice_price, stock: juice.juice_stock })
-
+    first_juices = []
+    5.times { first_juices.push Juice.new(juice[0], juice[1]) }
+    @juice_list = { juice[0] => first_juices }
     # 自動販売機の売上金額
     @sales_amount = 0
   end
@@ -19,19 +19,18 @@ class VendingMachine
     raise 'チャージ額またはジュースの在庫がありません' unless juice_buy?(suica, juice_name)
 
     # 自販機内のジュースの在庫を減らし、ジュースの値段分Suicaから引く、ジュースの値段分自販機の売上金額に追加
-    @juice_list[juice_name][:stock] -= 1
-    # suica.deposit_juice_price_sub(@juice_list[juice_name][:price])
-    @sales_amount += @juice_list[juice_name][:price]
-    suica.deposit_sub(@juice_list[juice_name][:price])
+    @sales_amount += @juice_list[juice_name].first.juice_price
+    suica.deposit_sub(@juice_list[juice_name].first.juice_price)
+    @juice_list[juice_name].delete_at(0)
   end
 
   # ジュースのストックを確認
   def juice_stock(juice_name)
-    @juice_list[juice_name][:stock]
+    @juice_list[juice_name].size
   end
 
   # Suicaの残高とジュースのストックで購入可能か判定
   def juice_buy?(suica, juice_name)
-    juice_stock(juice_name).positive? && suica.deposit >= @juice_list[juice_name][:price]
+    juice_stock(juice_name).positive? && suica.deposit >= @juice_list[juice_name].first.juice_price
   end
 end

--- a/ruby/vending_machine/test/advance_vending_machine.rb
+++ b/ruby/vending_machine/test/advance_vending_machine.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/advance_vending_machine'
+require_relative '../lib/juice'
+require_relative '../lib/suica'
+
+# 拡張された自動販売機のテストクラスです
+class AdvanceVendingMachineTest < Minitest::Test
+  def setup
+    @suica = Suica.new
+    pepsi = Juice.new
+    monster = Juice.new('モンスター', 230, 5)
+    ilohas = Juice.new('いろはす', 120, 5)
+    @adv_vending_machine = AdvanceVendingMachine.new(pepsi, monster, ilohas)
+  end
+
+  # 拡張された自動販売機は3種類のジュースを購入できる
+  def test_adv_vending_machine_offer_three_types_of_juice_for_buy
+    @adv_vending_machine.juice_buy(@suica, 'ペプシ')
+    @adv_vending_machine.juice_buy(@suica, 'モンスター')
+    @adv_vending_machine.juice_buy(@suica, 'いろはす')
+
+    # 購入後全てのジュースの在庫が-1
+    assert_equal 4, @adv_vending_machine.juice_stock('ペプシ')
+    assert_equal 4, @adv_vending_machine.juice_stock('モンスター')
+    assert_equal 4, @adv_vending_machine.juice_stock('いろはす')
+
+    # 売上金額が、150+230+120=500 となる
+    assert_equal 500, @adv_vending_machine.sales_amount
+
+    # 売上金額が500ということはSuicaの残高は0
+    assert_equal 0, @suica.deposit
+  end
+
+  # 拡張された自動販売機は購入可能なジュースのリストを返す
+  def test_adv_vending_machine_buy_possible_list
+    # Suicaの残高が500円かつ在庫十分なので全て購入可能
+    assert_equal %w[ペプシ モンスター いろはす], @adv_vending_machine.juice_buy_possible_list(@suica)
+
+    # Suicaの残高を120円に調整(期待されるのはいろはすのみ)
+    @adv_vending_machine.juice_buy(@suica, 'ペプシ')
+    @adv_vending_machine.juice_buy(@suica, 'モンスター')
+    assert_equal %w[いろはす], @adv_vending_machine.juice_buy_possible_list(@suica)
+
+    # ジュースの在庫がなくても表示されない
+    @suica.deposit_charge(1000)
+    4.times { @adv_vending_machine.juice_buy(@suica, 'ペプシ') }
+    assert_equal %w[モンスター いろはす], @adv_vending_machine.juice_buy_possible_list(@suica)
+  end
+
+  # 拡張された自動販売機は在庫を補充できる
+  def test_vending_machines_can_replenish_stock
+    # ペプシの在庫を+3, モンスターを+2, いろはすを+1
+    @adv_vending_machine.juice_stock_add('ペプシ', 3)
+    @adv_vending_machine.juice_stock_add('モンスター', 2)
+    @adv_vending_machine.juice_stock_add('いろはす', 1)
+
+    # 在庫を+した結果
+    assert_equal 8, @adv_vending_machine.juice_stock('ペプシ')
+    assert_equal 7, @adv_vending_machine.juice_stock('モンスター')
+    assert_equal 6, @adv_vending_machine.juice_stock('いろはす')
+  end
+end

--- a/ruby/vending_machine/test/advance_vending_machine.rb
+++ b/ruby/vending_machine/test/advance_vending_machine.rb
@@ -8,10 +8,10 @@ require_relative '../lib/suica'
 # 拡張された自動販売機のテストクラスです
 class AdvanceVendingMachineTest < Minitest::Test
   def setup
+    pepsi = ['ペプシ', 150]
+    monster = ['モンスター', 230]
+    ilohas = ['いろはす', 120]
     @suica = Suica.new
-    pepsi = Juice.new
-    monster = Juice.new('モンスター', 230, 5)
-    ilohas = Juice.new('いろはす', 120, 5)
     @adv_vending_machine = AdvanceVendingMachine.new(pepsi, monster, ilohas)
   end
 

--- a/ruby/vending_machine/test/juice_test.rb
+++ b/ruby/vending_machine/test/juice_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/juice'
+
+# ジュース作成をテストするクラスです
+class JuiceTest < Minitest::Test
+  def setup
+    @juice = Juice.new
+  end
+
+  # ジュースは名前、値段、在庫の情報を持っている
+  # デフォルトではペプシの情報が格納されている
+  def test_juice_has_name_price_stock_info
+    assert_equal 'ペプシ', @juice.juice_name
+    assert_equal 150, @juice.juice_price
+    assert_equal 5, @juice.juice_stock
+  end
+
+  # ジュースの名前、値段、在庫を指定して作成したインスタンスが機能しているか
+  def test_another_juice_instance
+    another_juice = Juice.new('アクエリアス', 140, 3)
+    assert_equal 'アクエリアス', another_juice.juice_name
+    assert_equal 140, another_juice.juice_price
+    assert_equal 3, another_juice.juice_stock
+  end
+end

--- a/ruby/vending_machine/test/suica_test.rb
+++ b/ruby/vending_machine/test/suica_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/suica'
+
+# Suicaをテストするクラスです
+class SuicaTest < Minitest::Test
+  # セットアップとしてSuicaのインスタンスを作成
+  def setup
+    @suica = Suica.new
+  end
+
+  # デフォルトで500円がチャージされているか確認
+  def test_default_deposit
+    assert_equal 500, @suica.deposit
+  end
+
+  # Suicaは100円以上の場合チャージできる
+  def test_more_than_100yen_can_be_charged_to_suica
+    assert @suica.deposit_charge(100)
+    # 100円チャージ後(600円)かを確認
+    assert_equal 600, @suica.deposit
+  end
+
+  # Suicaは100円未満の場合エラーを出力する
+  def test_less_than_100yen_cannot_be_charged_to_suica
+    e = assert_raises RuntimeError do
+      @suica.deposit_charge(99)
+    end
+    assert_equal 'チャージ額は100円以上で入力してください', e.message
+  end
+end

--- a/ruby/vending_machine/test/vending_machine_test.rb
+++ b/ruby/vending_machine/test/vending_machine_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/vending_machine'
+require_relative '../lib/juice'
+require_relative '../lib/suica'
+
+# 自動販売機をテストするクラスです
+class VendingMachineTest < Minitest::Test
+  def setup
+    @suica = Suica.new
+    pepsi = Juice.new
+    @vending_machine = VendingMachine.new(pepsi)
+  end
+
+  # 自動販売機はジュースを購入できる
+  def test_vending_machines_can_buy_canned_juice
+    # 購入処理
+    @vending_machine.juice_buy(@suica, 'ペプシ')
+    # ペプシ1缶を購入後の値
+    assert_equal 4, @vending_machine.juice_stock('ペプシ')
+    assert_equal 150, @vending_machine.sales_amount
+    assert_equal 350, @suica.deposit
+  end
+
+  # ジュースの在庫を取得できる
+  def test_vending_machine_can_get_stock
+    assert_equal 5, @vending_machine.juice_stock('ペプシ')
+  end
+
+  # 購入できるか判断できる
+  def test_determine_if_you_can_buy
+    assert @vending_machine.juice_buy?(@suica, 'ペプシ')
+
+    # Suicaの残高が足りないためfalse
+    3.times { @vending_machine.juice_buy(@suica, 'ペプシ') }
+    assert_equal false, @vending_machine.juice_buy?(@suica, 'ペプシ')
+
+    # 残高はあるが在庫が足りないためfalse
+    @suica.deposit_charge(1000)
+    2.times { @vending_machine.juice_buy(@suica, 'ペプシ') }
+    assert_equal false, @vending_machine.juice_buy?(@suica, 'ペプシ')
+  end
+
+  # 自動販売機は売上金額を取得できる
+  def test_vending_machines_can_capture_sales_amounts
+    # 1個も売れていないので0円
+    assert_equal 0, @vending_machine.sales_amount
+
+    # 合計2個売れたので300円
+    2.times { @vending_machine.juice_buy(@suica, 'ペプシ') }
+    assert_equal 300, @vending_machine.sales_amount
+
+    # 合計3個売れたので450円
+    @vending_machine.juice_buy(@suica, 'ペプシ')
+    assert_equal 450, @vending_machine.sales_amount
+  end
+end

--- a/ruby/vending_machine/test/vending_machine_test.rb
+++ b/ruby/vending_machine/test/vending_machine_test.rb
@@ -9,7 +9,8 @@ require_relative '../lib/suica'
 class VendingMachineTest < Minitest::Test
   def setup
     @suica = Suica.new
-    pepsi = Juice.new
+    # ジュースのインスタンス生成に必要な情報を記述
+    pepsi = ['ペプシ', 150]
     @vending_machine = VendingMachine.new(pepsi)
   end
 


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/08_ruby/003_%E8%87%AA%E8%B2%A9%E6%A9%9F%E5%95%8F%E9%A1%8C.md

## やったこと

* Suica版自動販売機の作成


## 動作確認方法

vending_machineディレクトリ直下で `rake` を実行すると各テストを実行できます。  
テストの内容は以下です。

### Suica Test
- デフォルトで500円がチャージできているか確認
- Suicaは100円以上の場合チャージでき、100円未満の場合エラーを出力する

### JuiceTest
- ジュースは名前、値段、在庫の情報を持っていることを確認
	- デフォルトではペプシの情報が格納されている(ペプシ、150円、在庫5)
- デフォルト以外のジュースの名前、値段、在庫を指定して作成したインスタンスが正しく機能しているか

### VendingMachineTest
- 自動販売機はジュースを購入でき、購入した際には在庫を-1し、売上をジュースの値段分追加、Suicaのデポジットとジュースの値段分-
- 自動販売機はジュースを購入できるか判断できる
	- Suicaの残高が足りない場合false
	- 残高があるが在庫がない場合false
- 自動販売機は売上金額を取得できる

### AdvanceVendingMachineTest
- 拡張された自動販売機は3種類のジュースを管理でき、購入できる
- 拡張された自動販売機は購入可能なジュースのリストを返す
	- ジュースの在庫がない場合にはリスト内に表示されない
- 拡張された自動販売機は在庫を補充できる

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点、困りごとなど）