### PR TITLE
ポケモンで学ぶ！クラスとオブジェクト指向PR

### DIFF
--- a/ruby/pokemon/Rakefile
+++ b/ruby/pokemon/Rakefile
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+  t.pattern = 'test/**/*_test.rb'
+end
+
+task default: :test

--- a/ruby/pokemon/lib/name_service.rb
+++ b/ruby/pokemon/lib/name_service.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# 名前変更に関するモジュールです
+module NameService
+  attr_reader :name
+
+  def change_name(new_name)
+    # 不適切な名前はエラー
+    raise '不適切な名前です' if new_name == 'うんこ'
+
+    @name = new_name
+  end
+end

--- a/ruby/pokemon/lib/pikachu.rb
+++ b/ruby/pokemon/lib/pikachu.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'pokemon'
+
+# ポケモンクラスを継承したピカチュウクラス
+class Picachu < Pokemon
+  def attack
+    "#{@name}の10万ボルト！"
+  end
+end

--- a/ruby/pokemon/lib/player.rb
+++ b/ruby/pokemon/lib/player.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'name_service'
+
+# プレイヤークラスです
+class Player
+  include NameService
+  def initialize(name)
+    @name = name
+  end
+end

--- a/ruby/pokemon/lib/pokemon.rb
+++ b/ruby/pokemon/lib/pokemon.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative 'name_service'
+
+# 抽象化クラスのように扱うポケモンクラスです
+class Pokemon
+  # NameServiceからname_changeメソッドとnameメソッドをinclude
+  include NameService
+
+  # 引数はrubocopのルールで3文字以上なので、hp => hitpoint に変更
+  def initialize(name, type1, type2, hitpoint)
+    @name = name
+    @type1 = type1
+    @type2 = type2
+    @hitpoint = hitpoint
+  end
+
+  # ポケモンがこうげきする処理(継承先でオーバーライドしないとエラー)
+  def attack
+    raise 'Method is abstract'
+  end
+end

--- a/ruby/pokemon/lib/zenigame.rb
+++ b/ruby/pokemon/lib/zenigame.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative 'pokemon'
+
+# ポケモンクラスを継承したゼニガメクラスです
+class Zenigame < Pokemon
+  def attack
+    "#{@name}のみずでっぽう！"
+  end
+end

--- a/ruby/pokemon/test/pikachu_test.rb
+++ b/ruby/pokemon/test/pikachu_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/pikachu'
+
+# ピカチュウをテストするクラスです
+class PikachuTest < Minitest::Test
+  def setup
+    @pikachu = Picachu.new('ピカチュウ', 'でんき', '', 100)
+  end
+
+  # 名前を取得できるかテスト
+  def test_get_name
+    assert_equal 'ピカチュウ', @pikachu.name
+  end
+
+  # ピカチュウは独自のこうげきができるかテスト
+  def test_pikachu_can_attack
+    assert_equal 'ピカチュウの10万ボルト！', @pikachu.attack
+  end
+
+  # 名前を変更できるかテスト
+  def test_name_change
+    @pikachu.change_name('ライチュウ')
+    assert_equal 'ライチュウ', @pikachu.name
+  end
+
+  # 不適切な名前(うんこ)で変更しようとした場合エラー
+  def test_misnomer_error
+    e = assert_raises RuntimeError do
+      @pikachu.change_name('うんこ')
+    end
+    assert_equal '不適切な名前です', e.message
+  end
+end

--- a/ruby/pokemon/test/player_test.rb
+++ b/ruby/pokemon/test/player_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/player'
+
+# プレイヤークラスをテストするクラスです
+class PlayerTest < Minitest::Test
+  def setup
+    @satoshi = Player.new('サトシ')
+  end
+
+  # プレイヤーの名前を取得できるかテスト
+  def test_get_name
+    assert_equal 'サトシ', @satoshi.name
+  end
+
+  # プレイヤーの名前を変更できるかテスト
+  def test_change_name
+    @satoshi.change_name('レッド')
+    assert_equal 'レッド', @satoshi.name
+  end
+
+  # 不適切な名前(うんこ)で変更しようとした場合エラー
+  def test_misnomer_error
+    e = assert_raises RuntimeError do
+      @satoshi.change_name('うんこ')
+    end
+    assert_equal '不適切な名前です', e.message
+  end
+end

--- a/ruby/pokemon/test/zenigame_test.rb
+++ b/ruby/pokemon/test/zenigame_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/zenigame'
+
+# ピカチュウをテストするクラスです
+class ZenigameTest < Minitest::Test
+  def setup
+    @zenigame = Zenigame.new('ゼニガメ', 'みず', '', 100)
+  end
+
+  # 名前を取得できるかテスト
+  def test_get_name
+    assert_equal 'ゼニガメ', @zenigame.name
+  end
+
+  # ゼニガメは独自のこうげきができるかテスト
+  def test_zenigame_can_attack
+    assert_equal 'ゼニガメのみずでっぽう！', @zenigame.attack
+  end
+
+  # 名前を変更できるかテスト
+  def test_name_change
+    @zenigame.change_name('カメール')
+    assert_equal 'カメール', @zenigame.name
+  end
+
+  # 不適切な名前(うんこ)で変更しようとした場合エラー
+  def test_misnomer_error
+    e = assert_raises RuntimeError do
+      @zenigame.change_name('うんこ')
+    end
+    assert_equal '不適切な名前です', e.message
+  end
+end


### PR DESCRIPTION
## 課題のリンク

* https://github.com/happiness-chain/practice/blob/main/08_ruby/004_ruby%E3%83%9D%E3%82%B1%E3%83%A2%E3%83%B3.md

## やったこと

* [ポケモンで学ぶ！クラスとオブジェクト指向](https://zenn.dev/m_coder/books/oop-learning-with-pokemon)を読み、Rubyで書き直す
* 抽象メソッドは `raise` を使用してオーバーライドしないと例外を出すように実装
* interfaceはmoduleを使用して実装


## 動作確認方法

pokemonディレクトリ直下で `rake` を実行すると各テストを実行できます。
テストの内容は以下です。

### PikachuTest
- 名前を取得できるか
- ピカチュウは独自のこうげきができるか
- 名前を変更できるか
- 不適切な名前(うんこ)で変更しようとした場合にエラー

### ZenigameTest
- 名前を取得できるか
- ゼニガメは独自のこうげきができるか
- 名前を変更できるか
- 不適切な名前(うんこ)で変更しようとした場合にエラー

### PlayerTest
- プレイヤーの名前を取得できるか
- プレイヤーの名前を変更できるか
- 不適切な名前(うんこ)で変更しようとした場合にエラー



## その他

* 特になし